### PR TITLE
fix travis badge, reduce dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ rust:
 # build nightly only for the time beeing
   - nightly
 
+# increase build speed by caching installed cargo dependencies
+cache: cargo
+
 # define the stages and their order
 stages:
   - compile
@@ -41,17 +44,17 @@ jobs:
     - stage: test
       name: "Run Doc Tests"
       install:
-        - rustc --print cfg
+        - cargo install cargo-make 
         # if we not build a PR we remove the patch of the dependencies to their github repo's
         - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "/{^\[patch\.crates-io\] /{:a;N;/\Z}/!ba};/^ruspiro-.*\(git\|path\).*/d" Cargo.toml; fi'
-      script: cargo test --doc --features ruspiro_pi3
+      script: cargo make doctest --profile dummy
     - stage: test
       name: "Run Unit Tests"
       install:
-        - rustc --print cfg
+        - cargo install cargo-make 
         # if we not build a PR we remove the patch of the dependencies to their github repo's
         - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "/{^\[patch\.crates-io\] /{:a;N;/\Z}/!ba};/^ruspiro-.*\(git\|path\).*/d" Cargo.toml; fi'
-      script: cargo test --tests --features ruspiro_pi3
+      script: cargo make unittest --profile dummy
 
     - stage: publish_dry
       name: "Run Cargo Publish Dry-Run"
@@ -62,7 +65,7 @@ jobs:
         - rustup target add aarch64-unknown-none
         - rustup component add rust-src
         - rustup component add llvm-tools-preview
-      script: cargo publish --dry-run --target aarch64-unknown-none --features ruspiro_pi3
+      script: cargo make publish_dry --profile travis
 
     - stage: prepare_release
       name: "Create PR against the release branch"
@@ -115,5 +118,7 @@ jobs:
         - sed -i -e 's/||VERSION||/'$CRATE_VERSION'/g' Cargo.toml
         # also update the version in the lib.rs doc root url
         - sed -i -e 's/||VERSION||/'$CRATE_VERSION'/g' src/lib.rs
+        # and the README.md
+        - sed -i -e 's/||VERSION||/'$CRATE_VERSION'/g' README.md
       # publish with token and dirty flag as we just updated some files and won't commit them back to the branch
-      script: cargo publish --token $CRATES_TOKEN --allow-dirty --target aarch64-unknown-none --features ruspiro_pi3
+      script: cargo make publish --profile travis --env CRATES_TOKEN="$CRATES_TOKEN" > /dev/null

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,10 +13,10 @@ name = "ruspiro-mmu"
 version = "0.1.0"
 dependencies = [
  "ruspiro-arch-aarch64",
- "ruspiro-register",
 ]
 
 [[package]]
 name = "ruspiro-register"
 version = "0.5.0"
-source = "git+https://github.com/RusPiRo/ruspiro-register.git?branch=master#e4e0f8590193e880b53d7a92c3f4aba5e9980f1b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba969505aa1ef93912baecd72cc13d6df2899d3a0d36b612157625b3392e68f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,11 @@ is-it-maintained-open-issues = { repository = "RusPiRo/ruspiro-mmu" }
 
 [dependencies]
 ruspiro-arch-aarch64 = "0.1"
-ruspiro-register = "0.5"
 
 [features]
 ruspiro_pi3 = [ 
     "ruspiro-arch-aarch64/ruspiro_pi3",
-    "ruspiro-register/ruspiro_pi3"
  ]
 
 [patch.crates-io]
 ruspiro-arch-aarch64 = { git = "https://github.com/RusPiRo/ruspiro-arch-aarch64.git", branch = "master" }
-ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git", branch = "master" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -34,12 +34,27 @@ args = ["clippy", "--target", "${BUILD_TARGET}", "--features", "${FEATURES}"]
 [tasks.doc]
 env = { FEATURES = "ruspiro_pi3" }
 command = "cargo"
-args = ["doc", "--target", "${BUILD_TARGET}", "--open"]
+args = ["doc", "--target", "${BUILD_TARGET}", "--features", "${FEATURES}", "--open"]
+
+[tasks.unittest]
+env = { FEATURES = "ruspiro_pi3" }
+command = "cargo"
+args = ["test", "--tests", "--features", "${FEATURES}"]
 
 [tasks.doctest]
 env = { FEATURES = "ruspiro_pi3" }
 command = "cargo"
-args = ["xtest", "--doc", "--target", "${BUILD_TARGET}"]
+args = ["test", "--doc", "--features", "${FEATURES}"]
+
+[tasks.publish_dry]
+env = { FEATURES = "ruspiro_pi3" }
+command = "cargo"
+args = ["publish", "--dry-run", "--target", "${BUILD_TARGET}", "--features", "${FEATURES}"]
+
+[tasks.publish]
+env = { FEATURES = "ruspiro_pi3" }
+command = "cargo"
+args = ["publish", "--token", "${CRATES_TOKEN}", "--allow-dirty", "--target", "${BUILD_TARGET}", "--features", "${FEATURES}"]
 
 [tasks.clean]
 command = "cargo"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The crate provides the API to configure and maintain the Raspberry Pi Memory Management Unit (MMU). It allows to maintain the EL2 and EL1 configuration settings.
 
-[![Travis-CI Status](https://api.travis-ci.org/RusPiRo/ruspiro-mmu.svg?branch=release)](https://travis-ci.org/RusPiRo/ruspiro-mmu)
+[![Travis-CI Status](https://api.travis-ci.com/RusPiRo/ruspiro-mmu.svg?branch=release)](https://travis-ci.com/RusPiRo/ruspiro-mmu)
 [![Latest Version](https://img.shields.io/crates/v/ruspiro-mmu.svg)](https://crates.io/crates/ruspiro-mmu)
 [![Documentation](https://docs.rs/ruspiro-mmu/badge.svg)](https://docs.rs/ruspiro-mmu)
 [![License](https://img.shields.io/crates/l/ruspiro-mmu.svg)](https://github.com/RusPiRo/ruspiro-mmu#license)

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,7 +60,7 @@
 //!  MemAttr | Stage 1 memory attributes - index into MAIR_ELx register
 
 use super::define_tlb_entry;
-use ruspiro_register::{RegisterField, RegisterFieldValue};
+use ruspiro_arch_aarch64::{RegisterField, RegisterFieldValue};
 
 pub const SECTION_SIZE: usize = 0x20_0000; // 2MB section size
 pub const SECTION_MASK: usize = SECTION_SIZE - 1;

--- a/src/el1.rs
+++ b/src/el1.rs
@@ -8,8 +8,10 @@
 //! # MMU Exception Level 1
 //!
 
-use ruspiro_arch_aarch64::instructions::{isb, nop};
-use ruspiro_arch_aarch64::register::el1::{mair_el1, sctlr_el1, tcr_el1, ttbr0_el1, ttbr1_el1};
+use ruspiro_arch_aarch64::{
+    instructions::{isb, nop},
+    register::el1::{mair_el1, sctlr_el1, tcr_el1, ttbr0_el1, ttbr1_el1},
+};
 
 pub fn enable_mmu(ttbr0_addr: u64, ttbr1_addr: u64) {
     // configure the MAIR (memory attribute) variations we will support

--- a/src/el2.rs
+++ b/src/el2.rs
@@ -8,8 +8,10 @@
 //! # MMU Exception Level 2
 //!
 
-use ruspiro_arch_aarch64::instructions::nop;
-use ruspiro_arch_aarch64::register::el2::{hcr_el2, mair_el2, sctlr_el2, tcr_el2, ttbr0_el2};
+use ruspiro_arch_aarch64::{
+    instructions::nop,
+    register::el2::{hcr_el2, mair_el2, sctlr_el2, tcr_el2, ttbr0_el2},
+};
 
 pub fn enable_mmu(ttlb_base_addr: u64) {
     // configure the MAIR (memory attribute) variations we will support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,11 @@ pub use config::TTLB_BLOCKPAGE;
 /// memory of the Raspberry Pi. Only the memory region from 0x3F00_0000 to 0x4002_0000 is configured
 /// as device memory as this is the area the memory mapped peripherals and the core mailboxes are
 /// located at.
-pub fn initialize(core: u32, vc_mem_start: u32, vc_mem_size: u32) {
+///
+/// # Safety
+/// The call to this function is safe when executed as part of the initial setup of the Raspberry Pi kernel and is
+/// called only once for each core.
+pub unsafe fn initialize(core: u32, vc_mem_start: u32, vc_mem_size: u32) {
     // the mmu configuration depends on the exception level we are running in
     let el = currentel::read(currentel::EL::Field).value();
 
@@ -41,11 +45,10 @@ pub fn initialize(core: u32, vc_mem_start: u32, vc_mem_size: u32) {
     }
 
     // setup translation table entries
-    let ttlb0_base_addr =
-        unsafe { ttbr0::setup_translation_tables(core, vc_mem_start, vc_mem_size) as u64 };
+    let ttlb0_base_addr = ttbr0::setup_translation_tables(core, vc_mem_start, vc_mem_size) as u64;
     match el {
         1 => {
-            let ttlb1_base_addr = unsafe { ttbr1::setup_translation_tables(core) as u64 };
+            let ttlb1_base_addr = ttbr1::setup_translation_tables(core) as u64;
             el1::enable_mmu(ttlb0_base_addr, ttlb1_base_addr);
         }
         2 => el2::enable_mmu(ttlb0_base_addr),
@@ -55,6 +58,7 @@ pub fn initialize(core: u32, vc_mem_start: u32, vc_mem_size: u32) {
 
 /// Map a given address to a virtual address with the specified memory attributes.
 /// TODO: Memory attributes shall be a specific allowed set only - create a new type for this!
+///
 /// # Safety
 /// This is safe if the MMU has been configured already. Also the given raw pointer need to point to an
 /// address provided from a call to `alloc::alloc(...)` with at least `size` bytes and is aligned to the actual

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,7 @@
 //! configured and active MMU is a prerequisit to use any atomic operations.
 //!
 
-use ruspiro_arch_aarch64::register::currentel;
-use ruspiro_register::{register_field, register_field_values};
+use ruspiro_arch_aarch64::{register::currentel, register_field, register_field_values};
 
 mod config;
 mod el1;


### PR DESCRIPTION
Fix travis-ci badge url to point to travis-ci.com now.
Remove dependency to `ruspiro-register` as it is re-exported from the `ruspiro-arch-aarch64` dependency already.